### PR TITLE
Fix MQTT string handling

### DIFF
--- a/examples/SimpleApp/platformio.ini
+++ b/examples/SimpleApp/platformio.ini
@@ -2,7 +2,7 @@
 default_envs = lilygo-t8
 
 [esp32base]
-platform = espressif32@~6.0.1
+platform = espressif32@~6.4.0
 framework = arduino
 ; From https://github.com/espressif/arduino-esp32/blob/674cf812e7feb42aafd644649c1889d59af447f2/tools/partitions/min_spiffs.csv
 board_build.partitions = partitions.csv

--- a/examples/SimpleApp/platformio.ini
+++ b/examples/SimpleApp/platformio.ini
@@ -18,8 +18,8 @@ monitor_speed = 115200
 upload_speed = 1500000
 
 [uart-cp2014]
-monitor_port = /dev/cu.usbserial*
-upload_port = /dev/cu.usbserial*
+;monitor_port = /dev/cu.usbserial*
+;upload_port = /dev/cu.usbserial*
 
 [uart-ch340]
 ;monitor_port = /dev/cu.wchusbserial*

--- a/farmhub-client/src/MqttHandler.hpp
+++ b/farmhub-client/src/MqttHandler.hpp
@@ -210,7 +210,6 @@ private:
     bool tryConnect() {
         // Lookup host name via MDNS explicitly
         // See https://github.com/kivancsikert/chicken-coop-door/issues/128
-        const String& hostname = hostname;
         if (hostname.isEmpty()) {
             bool found = mdns.withService(
                 "mqtt", "tcp",

--- a/farmhub-device.code-workspace
+++ b/farmhub-device.code-workspace
@@ -19,7 +19,21 @@
 			"functional": "cpp",
 			"chrono": "cpp",
 			"*.tpp": "cpp",
-			"string_view": "cpp"
+			"string_view": "cpp",
+			"array": "cpp",
+			"*.tcc": "cpp",
+			"deque": "cpp",
+			"list": "cpp",
+			"string": "cpp",
+			"unordered_map": "cpp",
+			"unordered_set": "cpp",
+			"vector": "cpp",
+			"memory": "cpp",
+			"random": "cpp",
+			"format": "cpp",
+			"mutex": "cpp",
+			"span": "cpp",
+			"initializer_list": "cpp"
 		},
 		"cSpell.words": [
 			"bblanchon",


### PR DESCRIPTION
This removes an unnecessary line that seems to confuse PlatformIO 3.3.1 / Espressif32 platform 6.4.0. It seems to have worked fine before.